### PR TITLE
a small typo in renviron file location + structure

### DIFF
--- a/R/isop_login.R
+++ b/R/isop_login.R
@@ -52,9 +52,9 @@ isop_login <- function(username = NULL,
     if (missing(password)) {
        password <- getPass::getPass(msg = "Password: ")
         if (store) {
-            ndop_user <- paste("NDOP_USER", "=", username)
-            write(ndop_user, file = " ~/.Renviron", append = TRUE)
-            ndop_pwd <- paste("NDOP_PWD","=", password)
+            ndop_user <- paste0("NDOP_USER='", username, "'")
+            write(ndop_user, file = "~/.Renviron", append = TRUE)
+            ndop_pwd <- paste0("NDOP_PWD='", password,"'")
             write(ndop_pwd, file = "~/.Renviron", append = TRUE)
         }
     }

--- a/R/ndop_search.R
+++ b/R/ndop_search.R
@@ -67,6 +67,8 @@ ndop_search <- function(search_payload){
                            config = httr::set_cookies(
                                             isop_loginhash = isop_loginhash))
     }
+    
+    Sys.sleep(3)
 
     num_rec_ind <- gregexpr("záznam ze \\d+", 
                             httr::content(filter_page, 


### PR DESCRIPTION
First of all: thanks for a great package, strange that something like this was not done yet... It is 2023 for Pete's sake :)

Secondly: I had slight issues with storing my login creds in the  `.Renviron` file, nothing truly serious: extra space in filename and single quotation marks as string separators. It made the crash go away...

Thanks again!